### PR TITLE
not serializable fix

### DIFF
--- a/logger/formatter.py
+++ b/logger/formatter.py
@@ -17,9 +17,12 @@ class JSONLogFormatter(logging.Formatter):
         :return: строка журнала в JSON формате
         """
         log_object: dict = self._format_log_object(record)
-        return json.dumps(log_object, ensure_ascii=False,
-                          skipkeys=True,
-                          default=lambda o: f'<{type(o)=} not serializable>')
+        return json.dumps(
+            log_object,
+            ensure_ascii=False,
+            skipkeys=True,
+            default=lambda o: f"<{type(o)=} not serializable>",
+        )
 
     @staticmethod
     def _format_log_object(record: logging.LogRecord) -> dict:
@@ -49,7 +52,6 @@ class JSONLogFormatter(logging.Formatter):
         json_log_fields["duration_ms"] = duration_ms
         json_log_fields["func"] = record.funcName
         json_log_fields["file"] = record.filename
-
         empty_record = logging.LogRecord(
             str(), int(), str(), int(), object(), exc_info=None, args=(object,)
         )

--- a/logger/formatter.py
+++ b/logger/formatter.py
@@ -17,7 +17,9 @@ class JSONLogFormatter(logging.Formatter):
         :return: строка журнала в JSON формате
         """
         log_object: dict = self._format_log_object(record)
-        return json.dumps(log_object, ensure_ascii=False)
+        return json.dumps(log_object, ensure_ascii=False,
+                          skipkeys=True,
+                          default=lambda o: f'<{type(o)=} not serializable>')
 
     @staticmethod
     def _format_log_object(record: logging.LogRecord) -> dict:
@@ -47,6 +49,7 @@ class JSONLogFormatter(logging.Formatter):
         json_log_fields["duration_ms"] = duration_ms
         json_log_fields["func"] = record.funcName
         json_log_fields["file"] = record.filename
+
         empty_record = logging.LogRecord(
             str(), int(), str(), int(), object(), exc_info=None, args=(object,)
         )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="logging_profcomff",
-    version="2023.03.11",
+    version="2023.10.29",
     author="Semyon Grigoriev",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Изменения
Теперь вместо рейза ошибки при попытке залогировать что то не переводимое в json.dumps он не будет падать

## Check-List
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
